### PR TITLE
Fix JSON include path and ensure build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/core
     ${CMAKE_SOURCE_DIR}/shared
+    ${CMAKE_SOURCE_DIR}/third_party
     ${PORTAUDIO_INCLUDE_DIR}
     ${LAME_INCLUDE_DIR}
     ${RTMIDI_INCLUDE_DIR}


### PR DESCRIPTION
## Summary
- add `third_party` to CMake include directories so bundled headers resolve

## Testing
- `./build_and_test_improved.sh`

------
https://chatgpt.com/codex/tasks/task_e_68550eb271b083339f9de20830a99b80