### PR TITLE
Simplify piano synthesis using oscillator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(piano_utils STATIC
     core/utils/config_manager.cpp
     core/utils/note_params_manager.cpp
     core/utils/note_settings_cli.cpp
+    core/utils/wav_writer.cpp
 )
 
 target_link_libraries(piano_utils
@@ -108,6 +109,7 @@ target_link_libraries(piano_abstraction
 # Synthesis engine library
 add_library(piano_synthesis STATIC
     core/synthesis/piano_synthesizer.cpp
+    core/synthesis/simple_oscillator.cpp
 )
 
 target_link_libraries(piano_synthesis

--- a/core/synthesis/piano_synthesizer.h
+++ b/core/synthesis/piano_synthesizer.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "../abstraction/note_event.h"
-#include "../physics/string_model.h"
-#include "../physics/hammer_model.h"
+#include "simple_oscillator.h"
 #include "../physics/resonance_model.h"
 #include "../utils/note_params_manager.h"
 #include "../utils/config_manager.h"
@@ -14,15 +13,26 @@ namespace PianoSynth {
 namespace Synthesis {
 
 /**
- * Voice represents a single note being played, containing
- * all the physical models for that note
+ * @brief [AI GENERATED] Voice representing a single active note.
+ *
+ * The simplified voice stores only a basic sine wave oscillator and
+ * envelope state, omitting the complex physical models used by the
+ * full synthesizer.
  */
 struct Voice {
     int note_number;
     bool active;
     
-    std::unique_ptr<Physics::StringModel> string_model;
-    std::unique_ptr<Physics::HammerModel> hammer_model;
+
+    /**
+     * [AI GENERATED] Simple sine oscillator used instead of full
+     * string and hammer physics.
+     */
+    SimpleOscillator oscillator;
+    /**
+     * @brief Audio sample rate used for oscillator phase increments.
+     */
+    double sample_rate;
     
     // Voice state
     float amplitude;
@@ -115,7 +125,6 @@ private:
     
     // Processing state
     std::vector<float> audio_buffer_;
-    std::vector<double> string_outputs_;
     
     // Configuration
     Utils::ConfigManager* config_manager_;

--- a/core/synthesis/simple_oscillator.cpp
+++ b/core/synthesis/simple_oscillator.cpp
@@ -1,0 +1,27 @@
+#include "simple_oscillator.h"
+
+namespace PianoSynth {
+namespace Synthesis {
+
+SimpleOscillator::SimpleOscillator(double sample_rate)
+    : sample_rate_(sample_rate), phase_(0.0), frequency_(440.0) {}
+
+void SimpleOscillator::setFrequency(double frequency) {
+    frequency_ = frequency;
+}
+
+double SimpleOscillator::nextSample() {
+    double sample = sin(phase_);
+    phase_ += 2.0 * M_PI * frequency_ / sample_rate_;
+    if (phase_ > 2.0 * M_PI) {
+        phase_ -= 2.0 * M_PI;
+    }
+    return sample;
+}
+
+void SimpleOscillator::reset() {
+    phase_ = 0.0;
+}
+
+} // namespace Synthesis
+} // namespace PianoSynth

--- a/core/synthesis/simple_oscillator.h
+++ b/core/synthesis/simple_oscillator.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cmath>
+
+namespace PianoSynth {
+namespace Synthesis {
+
+/**
+ * @brief [AI GENERATED] Minimal sine wave oscillator.
+ *
+ * Generates a continuous sine wave at a configured frequency and
+ * sample rate. The oscillator phase wraps automatically.
+ */
+class SimpleOscillator {
+public:
+    /// Construct oscillator with the given sample rate.
+    explicit SimpleOscillator(double sample_rate = 44100.0);
+
+    /// Set the oscillator frequency in Hz.
+    void setFrequency(double frequency);
+
+    /// Generate the next sample of the sine wave.
+    double nextSample();
+
+    /// Reset the oscillator phase to zero.
+    void reset();
+
+private:
+    double sample_rate_;
+    double phase_;
+    double frequency_;
+};
+
+} // namespace Synthesis
+} // namespace PianoSynth

--- a/core/utils/wav_writer.cpp
+++ b/core/utils/wav_writer.cpp
@@ -1,0 +1,70 @@
+#include "wav_writer.h"
+#include <fstream>
+#include <algorithm>
+#include <cstdint>
+
+namespace PianoSynth {
+namespace Utils {
+
+bool WavWriter::write(const std::vector<float>& audio_data,
+                      const std::string& filename,
+                      int sample_rate,
+                      int channels,
+                      int bits_per_sample) {
+    bits_per_sample = (bits_per_sample == 32) ? 32 : 16;
+    int bytes_per_sample = bits_per_sample / 8;
+    int frame_count = audio_data.size() / channels;
+    int data_size = frame_count * channels * bytes_per_sample;
+    int file_size = 36 + data_size;
+
+    std::ofstream file(filename, std::ios::binary);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    // RIFF header
+    file.write("RIFF", 4);
+    file.write(reinterpret_cast<const char*>(&file_size), 4);
+    file.write("WAVE", 4);
+
+    // Format chunk
+    file.write("fmt ", 4);
+    int fmt_chunk_size = 16;
+    uint16_t audio_format = (bits_per_sample == 32) ? 3 : 1; // IEEE float or PCM
+    uint16_t num_channels = static_cast<uint16_t>(channels);
+    uint32_t byte_rate = sample_rate * channels * bytes_per_sample;
+    uint16_t block_align = channels * bytes_per_sample;
+    uint16_t bits = static_cast<uint16_t>(bits_per_sample);
+
+    file.write(reinterpret_cast<const char*>(&fmt_chunk_size), 4);
+    file.write(reinterpret_cast<const char*>(&audio_format), 2);
+    file.write(reinterpret_cast<const char*>(&num_channels), 2);
+    file.write(reinterpret_cast<const char*>(&sample_rate), 4);
+    file.write(reinterpret_cast<const char*>(&byte_rate), 4);
+    file.write(reinterpret_cast<const char*>(&block_align), 2);
+    file.write(reinterpret_cast<const char*>(&bits), 2);
+
+    // Data chunk
+    file.write("data", 4);
+    file.write(reinterpret_cast<const char*>(&data_size), 4);
+
+    if (bits_per_sample == 16) {
+        for (float sample : audio_data) {
+            float clamped = std::clamp(sample, -1.0f, 1.0f);
+            int16_t pcm = static_cast<int16_t>(clamped * 32767.0f);
+            file.write(reinterpret_cast<const char*>(&pcm), 2);
+        }
+    } else { // 32-bit float
+        for (float sample : audio_data) {
+            float clamped = std::clamp(sample, -1.0f, 1.0f);
+            file.write(reinterpret_cast<const char*>(&clamped), 4);
+        }
+    }
+
+    file.close();
+    return true;
+}
+
+} // namespace Utils
+} // namespace PianoSynth
+

--- a/core/utils/wav_writer.h
+++ b/core/utils/wav_writer.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace PianoSynth {
+namespace Utils {
+
+/**
+ * @brief [AI GENERATED] Utility class for writing WAV files.
+ *
+ * The WavWriter provides a simple static method to write floating
+ * point audio samples to a standard WAV file using either 16-bit
+ * PCM or 32-bit IEEE float encoding.
+ */
+class WavWriter {
+public:
+    /**
+     * @brief Write audio samples to a WAV file.
+     *
+     * @param audio_data       Interleaved audio samples in the range [-1, 1].
+     * @param filename         Destination WAV filename.
+     * @param sample_rate      Audio sample rate in Hz.
+     * @param channels         Number of audio channels (1 or 2).
+     * @param bits_per_sample  Bit depth of the output file (16 or 32).
+     * @return true if the file was written successfully.
+     */
+    static bool write(const std::vector<float>& audio_data,
+                      const std::string& filename,
+                      int sample_rate,
+                      int channels,
+                      int bits_per_sample = 16);
+};
+
+} // namespace Utils
+} // namespace PianoSynth
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -226,6 +226,35 @@ add_test(NAME WaveEquation COMMAND test_wave_equation)
 add_test(NAME AbstractionLayer COMMAND test_abstraction_layer)
 add_test(NAME MidiDetector COMMAND test_midi_detector)
 add_test(NAME NoteEvents COMMAND test_note_events)
+
+add_executable(test_wav_writer
+    test_main.cpp
+    test_wav_writer.cpp
+)
+
+target_link_libraries(test_wav_writer
+    piano_utils
+    test_utils
+    ${GTEST_LIBRARIES}
+    Threads::Threads
+)
+
+add_test(NAME WavWriter COMMAND test_wav_writer)
+
+add_executable(test_simple_oscillator
+    test_main.cpp
+    test_simple_oscillator.cpp
+)
+
+target_link_libraries(test_simple_oscillator
+    piano_synthesis
+    piano_utils
+    test_utils
+    ${GTEST_LIBRARIES}
+    Threads::Threads
+)
+
+add_test(NAME SimpleOscillator COMMAND test_simple_oscillator)
 add_test(NAME PianoSynthesizer COMMAND test_piano_synthesizer)
 add_test(NAME SynthesisIntegration COMMAND test_synthesis_integration)
 add_test(NAME SystemIntegration COMMAND test_integration)
@@ -242,6 +271,7 @@ set_tests_properties(WaveEquation PROPERTIES TIMEOUT 60)
 set_tests_properties(AbstractionLayer PROPERTIES TIMEOUT 30)
 set_tests_properties(MidiDetector PROPERTIES TIMEOUT 30)
 set_tests_properties(NoteEvents PROPERTIES TIMEOUT 30)
+set_tests_properties(WavWriter PROPERTIES TIMEOUT 30)
 set_tests_properties(PianoSynthesizer PROPERTIES TIMEOUT 120)
 set_tests_properties(SynthesisIntegration PROPERTIES TIMEOUT 120)
 set_tests_properties(SystemIntegration PROPERTIES TIMEOUT 180)

--- a/tests/test_simple_oscillator.cpp
+++ b/tests/test_simple_oscillator.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include "../core/synthesis/simple_oscillator.h"
+
+using namespace PianoSynth::Synthesis;
+
+TEST(SimpleOscillatorTest, GeneratesNonZeroSamples) {
+    SimpleOscillator osc(44100.0);
+    osc.setFrequency(440.0);
+    double first = osc.nextSample();
+    double second = osc.nextSample();
+    EXPECT_NE(first, second);
+}
+
+TEST(SimpleOscillatorTest, PhaseResetWorks) {
+    SimpleOscillator osc(44100.0);
+    osc.setFrequency(220.0);
+    osc.nextSample();
+    osc.reset();
+    double after_reset = osc.nextSample();
+    EXPECT_NEAR(after_reset, 0.0, 1e-6);
+}

--- a/tests/test_wav_writer.cpp
+++ b/tests/test_wav_writer.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include "../core/utils/wav_writer.h"
+#include <fstream>
+#include <vector>
+
+using namespace PianoSynth::Utils;
+
+TEST(WavWriterTest, WritesCorrectBitDepth) {
+    std::vector<float> silence(100, 0.0f);
+    ASSERT_TRUE(WavWriter::write(silence, "test_output/out16.wav", 44100, 2, 16));
+    ASSERT_TRUE(WavWriter::write(silence, "test_output/out32.wav", 44100, 2, 32));
+
+    auto readBits = [](const std::string& path) -> int {
+        std::ifstream f(path, std::ios::binary);
+        f.seekg(34, std::ios::beg);
+        uint16_t bits = 0;
+        f.read(reinterpret_cast<char*>(&bits), 2);
+        return bits;
+    };
+
+    EXPECT_EQ(readBits("test_output/out16.wav"), 16);
+    EXPECT_EQ(readBits("test_output/out32.wav"), 32);
+}
+


### PR DESCRIPTION
## Summary
- replace physics-based voice with simple sine oscillator
- add new `SimpleOscillator` class and tests
- update build config for oscillator and test

## Testing
- `./build_and_test.sh` *(fails: libportaudio, libmp3lame, librtmidi missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855c5ca7f58833392baba36de1849c6