### PR TITLE
Enhance oscillator with noise and decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A realistic piano synthesizer that uses physical modeling instead of sampling. T
 ### Realistic Physics
 - **No Sampling**: Pure mathematical modeling of piano physics
 - **String Theory**: Based on actual string vibration equations
+- **String Noise**: Subtle noise and natural decay emulate real string dynamics
 - **Material Properties**: Uses real physical constants for steel strings, wood soundboard
 - **Harmonic Accuracy**: Natural generation of harmonic content and beating
 

--- a/SOUND_QUALITY_IMPROVEMENTS.md
+++ b/SOUND_QUALITY_IMPROVEMENTS.md
@@ -74,6 +74,8 @@ double amplitude = excitation_force_ * position_factor * harmonic_decay * freq_r
 - **Enhanced Envelopes**: Implemented more realistic piano decay curves
 - **Strike Parameter Variation**: Varied strike position and force based on velocity
 - **Smooth Release**: Exponential release curves instead of linear
+- **String Noise & Decay**: Basic oscillator now injects gentle noise and
+  automatically decays amplitude to mimic real string vibration
 
 #### Code Example - Improved Audio Processing:
 ```cpp


### PR DESCRIPTION
## Summary
- add natural noise and amplitude decay in `SimpleOscillatorInstrument`
- document new behaviour in README and sound improvements docs
- test decay behaviour with new unit test

## Testing
- `./build_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_685675f6615c8333b1e94afbdaef737c