### PR TITLE
Implement decaying string envelope

### DIFF
--- a/include/NoteSynth.h
+++ b/include/NoteSynth.h
@@ -1,6 +1,7 @@
 /**
  * @file NoteSynth.h
- * @brief [AI GENERATED] Basic oscillator-based synth.
+ * @brief [AI GENERATED] Basic oscillator-based synth with simple
+ * string-decay emulation.
  */
 
 #pragma once
@@ -12,5 +13,14 @@
  */
 class NoteSynth {
 public:
-    std::vector<double> synthesize(const std::vector<NoteEvent>& events, int sampleRate = 44100) const;
+    /**
+     * @brief [AI GENERATED] Convert note events to samples using an
+     * exponential decay envelope.
+     *
+     * @param events Sequence of notes to synthesize.
+     * @param sampleRate Target sample rate for output audio.
+     * @return Vector containing synthesized PCM samples.
+     */
+    std::vector<double> synthesize(const std::vector<NoteEvent>& events,
+                                   int sampleRate = 44100) const;
 };

--- a/src/NoteSynth.cpp
+++ b/src/NoteSynth.cpp
@@ -2,14 +2,17 @@
 #include <cmath>
 
 /**
- * @brief [AI GENERATED] Generate audio samples using a sine wave.
+ * @brief [AI GENERATED] Generate audio samples using a sine wave with an
+ * exponential decay envelope to emulate a piano string losing energy.
  */
 std::vector<double> NoteSynth::synthesize(const std::vector<NoteEvent>& events, int sampleRate) const {
     std::vector<double> samples;
     for (const auto& e : events) {
-        int count = static_cast<int>(e.duration * sampleRate);
+        const int count = static_cast<int>(e.duration * sampleRate);
         for (int i = 0; i < count; ++i) {
-            double value = std::sin(2.0 * M_PI * e.frequency * i / sampleRate);
+            const double phase = 2.0 * M_PI * e.frequency * static_cast<double>(i) / sampleRate;
+            const double envelope = std::exp(-3.0 * static_cast<double>(i) / static_cast<double>(count));
+            const double value = envelope * std::sin(phase);
             samples.push_back(value);
         }
     }

--- a/tests/test_synth.cpp
+++ b/tests/test_synth.cpp
@@ -23,6 +23,14 @@ int main() {
     auto samples = synth.synthesize(notes, 8000);
     assert(!samples.empty());
 
+    int firstCount = static_cast<int>(notes[0].duration * 8000);
+    int quarterIdx = static_cast<int>(8000 / (4.0 * notes[0].frequency));
+    if (quarterIdx >= firstCount) {
+        quarterIdx = 0;
+    }
+    int endIdx = firstCount - quarterIdx - 1;
+    assert(std::abs(samples[endIdx]) < std::abs(samples[quarterIdx]));
+
     OutputHandler out;
     const std::string file = "test.wav";
     out.writeWav(samples, file, 8000);


### PR DESCRIPTION
## Summary
- refine `NoteSynth` to apply a simple exponential decay
- document new behaviour in the header
- test that sample amplitude decreases over a note

## Testing
- `./build_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856801bc4808333a934adc42085c75e