### PR TITLE
Add sustain and hammer noise demo

### DIFF
--- a/src/MidiInput.cpp
+++ b/src/MidiInput.cpp
@@ -1,14 +1,15 @@
 #include "MidiInput.h"
 
 /**
- * @brief [AI GENERATED] Generates a short melody.
+ * @brief [AI GENERATED] Generates the opening phrase of Fur Elise with
+ *        extended key presses.
  */
 std::vector<MidiMessage> MidiInput::generateDemo() const {
-    int tune[] = {64, 62, 60, 62, 64, 64, 64, 62, 62, 62, 64, 67, 67};
-    const double dur = 0.5;
+    const int kNotes[] = {76, 75, 76, 75, 76, 71, 74, 73, 69};
+    const double kDurations[] = {0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 1.6};
     std::vector<MidiMessage> messages;
-    for (int n : tune) {
-        messages.push_back({n, dur});
+    for (size_t i = 0; i < sizeof(kNotes) / sizeof(kNotes[0]); ++i) {
+        messages.push_back({kNotes[i], kDurations[i]});
     }
     return messages;
 }

--- a/src/NoteSynth.cpp
+++ b/src/NoteSynth.cpp
@@ -1,18 +1,36 @@
 #include "NoteSynth.h"
 #include <cmath>
+#include <cstdlib>
 
 /**
- * @brief [AI GENERATED] Generate audio samples using a sine wave with an
- * exponential decay envelope to emulate a piano string losing energy.
+ * @brief [AI GENERATED] Generate samples with a sustain phase and hammer noise.
  */
-std::vector<double> NoteSynth::synthesize(const std::vector<NoteEvent>& events, int sampleRate) const {
+std::vector<double> NoteSynth::synthesize(const std::vector<NoteEvent>& events,
+                                          int sampleRate) const {
     std::vector<double> samples;
+    const double kHammerTime = 0.02;
+    const double kSustainFraction = 0.7;
     for (const auto& e : events) {
         const int count = static_cast<int>(e.duration * sampleRate);
+        int hammerSamples = static_cast<int>(kHammerTime * sampleRate);
+        if (hammerSamples > count) {
+            hammerSamples = count;
+        }
+        const int sustainStart = static_cast<int>(kSustainFraction * count);
         for (int i = 0; i < count; ++i) {
             const double phase = 2.0 * M_PI * e.frequency * static_cast<double>(i) / sampleRate;
-            const double envelope = std::exp(-3.0 * static_cast<double>(i) / static_cast<double>(count));
-            const double value = envelope * std::sin(phase);
+            double value = 0.0;
+            if (i < hammerSamples) {
+                const double noise = static_cast<double>(std::rand()) / RAND_MAX * 2.0 - 1.0;
+                value += 0.3 * noise;
+            }
+            double envelope = 1.0;
+            if (i > sustainStart) {
+                const double release = static_cast<double>(i - sustainStart);
+                const double releaseLen = static_cast<double>(count - sustainStart);
+                envelope = std::exp(-3.0 * release / releaseLen);
+            }
+            value += envelope * std::sin(phase);
             samples.push_back(value);
         }
     }

--- a/tests/test_synth.cpp
+++ b/tests/test_synth.cpp
@@ -3,6 +3,7 @@
 #include "NoteSynth.h"
 #include "OutputHandler.h"
 #include <cassert>
+#include <cmath>
 #include <filesystem>
 #include <iostream>
 
@@ -24,12 +25,15 @@ int main() {
     assert(!samples.empty());
 
     int firstCount = static_cast<int>(notes[0].duration * 8000);
+    assert(firstCount >= static_cast<int>(0.8 * 8000));
     int quarterIdx = static_cast<int>(8000 / (4.0 * notes[0].frequency));
     if (quarterIdx >= firstCount) {
         quarterIdx = 0;
     }
     int endIdx = firstCount - quarterIdx - 1;
-    assert(std::abs(samples[endIdx]) < std::abs(samples[quarterIdx]));
+    assert(samples[0] != 0.0);
+    int sustainIdx = static_cast<int>(firstCount * 0.7);
+    assert(std::abs(samples[endIdx]) < std::abs(samples[sustainIdx]));
 
     OutputHandler out;
     const std::string file = "test.wav";


### PR DESCRIPTION
## Summary
- switch demo tune to Fur Elise with longer sustain
- add sustain and hammer noise implementation in NoteSynth
- test new functionality and noise behavior

## Testing
- `./build_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_685686623aac8333a5b3741894b8968e