### PR TITLE
Improve sound realism and add chords

### DIFF
--- a/include/Abstractor.h
+++ b/include/Abstractor.h
@@ -8,9 +8,13 @@
 #include <cmath>
 #include "MidiInput.h"
 
+/**
+ * @brief [AI GENERATED] Represents a synthesized note event.
+ */
 struct NoteEvent {
-    double frequency;
-    double duration;
+    double frequency;  /**< Frequency of the note in Hz. */
+    double duration;   /**< Duration of the note in seconds. */
+    double startTime;  /**< Start time of the note in seconds. */
 };
 
 /**

--- a/include/MidiInput.h
+++ b/include/MidiInput.h
@@ -6,9 +6,13 @@
 #pragma once
 #include <vector>
 
+/**
+ * @brief [AI GENERATED] Represents a single MIDI note message.
+ */
 struct MidiMessage {
-    int note;
-    double duration;
+    int note;          /**< MIDI note number. */
+    double duration;   /**< Duration of the note in seconds. */
+    double startTime;  /**< Start time of the note in seconds. */
 };
 
 /**

--- a/include/NoteSynth.h
+++ b/include/NoteSynth.h
@@ -9,7 +9,8 @@
 #include "Abstractor.h"
 
 /**
- * @brief [AI GENERATED] Converts note events into audio samples.
+ * @brief [AI GENERATED] Converts note events into audio samples. Supports
+ * overlapping notes for simple chord playback.
  */
 class NoteSynth {
 public:

--- a/src/Abstractor.cpp
+++ b/src/Abstractor.cpp
@@ -7,7 +7,7 @@ std::vector<NoteEvent> Abstractor::convert(const std::vector<MidiMessage>& midi)
     std::vector<NoteEvent> events;
     for (const auto& msg : midi) {
         double freq = 440.0 * std::pow(2.0, (msg.note - 69) / 12.0);
-        events.push_back({freq, msg.duration});
+        events.push_back({freq, msg.duration, msg.startTime});
     }
     return events;
 }

--- a/src/MidiInput.cpp
+++ b/src/MidiInput.cpp
@@ -5,11 +5,21 @@
  *        extended key presses.
  */
 std::vector<MidiMessage> MidiInput::generateDemo() const {
-    const int kNotes[] = {76, 75, 76, 75, 76, 71, 74, 73, 69};
-    const double kDurations[] = {0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 1.6};
+    // Opening phrase with a triad chord at the beginning.
+    const int kNotes[] = {76, 80, 83, 75, 76, 75, 76, 71, 74, 73, 69};
+    const double kDurations[] = {0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 1.6};
+
     std::vector<MidiMessage> messages;
-    for (size_t i = 0; i < sizeof(kNotes) / sizeof(kNotes[0]); ++i) {
-        messages.push_back({kNotes[i], kDurations[i]});
+    double dCurrentTime = 0.0;
+    // First three notes start simultaneously to form a chord.
+    for (int i = 0; i < 3; ++i) {
+        messages.push_back({kNotes[i], kDurations[i], 0.0});
+    }
+    dCurrentTime += kDurations[0];
+    // Remaining notes are played sequentially.
+    for (size_t i = 3; i < sizeof(kNotes) / sizeof(kNotes[0]); ++i) {
+        messages.push_back({kNotes[i], kDurations[i], dCurrentTime});
+        dCurrentTime += kDurations[i];
     }
     return messages;
 }

--- a/src/NoteSynth.cpp
+++ b/src/NoteSynth.cpp
@@ -1,37 +1,46 @@
 #include "NoteSynth.h"
 #include <cmath>
 #include <cstdlib>
+#include <algorithm>
 
 /**
  * @brief [AI GENERATED] Generate samples with a sustain phase and hammer noise.
  */
 std::vector<double> NoteSynth::synthesize(const std::vector<NoteEvent>& events,
                                           int sampleRate) const {
-    std::vector<double> samples;
     const double kHammerTime = 0.02;
     const double kSustainFraction = 0.7;
+    double dTotalDuration = 0.0;
     for (const auto& e : events) {
-        const int count = static_cast<int>(e.duration * sampleRate);
-        int hammerSamples = static_cast<int>(kHammerTime * sampleRate);
-        if (hammerSamples > count) {
-            hammerSamples = count;
+        dTotalDuration = std::max(dTotalDuration, e.startTime + e.duration);
+    }
+
+    const int iTotalSamples = static_cast<int>(dTotalDuration * sampleRate);
+    std::vector<double> samples(iTotalSamples, 0.0);
+
+    for (const auto& e : events) {
+        const int iStart = static_cast<int>(e.startTime * sampleRate);
+        const int iCount = static_cast<int>(e.duration * sampleRate);
+        int iHammerSamples = static_cast<int>(kHammerTime * sampleRate);
+        if (iHammerSamples > iCount) {
+            iHammerSamples = iCount;
         }
-        const int sustainStart = static_cast<int>(kSustainFraction * count);
-        for (int i = 0; i < count; ++i) {
-            const double phase = 2.0 * M_PI * e.frequency * static_cast<double>(i) / sampleRate;
-            double value = 0.0;
-            if (i < hammerSamples) {
-                const double noise = static_cast<double>(std::rand()) / RAND_MAX * 2.0 - 1.0;
-                value += 0.3 * noise;
+        const int iSustainStart = static_cast<int>(kSustainFraction * iCount);
+        for (int i = 0; i < iCount; ++i) {
+            const double dPhase = 2.0 * M_PI * e.frequency * static_cast<double>(i) / sampleRate;
+            double dValue = std::sin(dPhase) + 0.3 * std::sin(2.0 * dPhase);
+            if (i < iHammerSamples) {
+                const double dNoise = static_cast<double>(std::rand()) / RAND_MAX * 2.0 - 1.0;
+                const double dHammerEnv = 1.0 - static_cast<double>(i) / iHammerSamples;
+                dValue += 0.05 * dHammerEnv * dNoise;
             }
-            double envelope = 1.0;
-            if (i > sustainStart) {
-                const double release = static_cast<double>(i - sustainStart);
-                const double releaseLen = static_cast<double>(count - sustainStart);
-                envelope = std::exp(-3.0 * release / releaseLen);
+            double dEnvelope = 1.0;
+            if (i > iSustainStart) {
+                const double dRelease = static_cast<double>(i - iSustainStart);
+                const double dReleaseLen = static_cast<double>(iCount - iSustainStart);
+                dEnvelope = std::exp(-3.0 * dRelease / dReleaseLen);
             }
-            value += envelope * std::sin(phase);
-            samples.push_back(value);
+            samples[iStart + i] += dEnvelope * dValue;
         }
     }
     return samples;

--- a/tests/test_synth.cpp
+++ b/tests/test_synth.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <filesystem>
 #include <iostream>
+#include <cstdlib>
 
 /**
  * @brief [AI GENERATED] Basic integration tests for synthesizer modules.
@@ -14,25 +15,32 @@ int main() {
     MidiInput midi;
     auto midiData = midi.generateDemo();
     assert(!midiData.empty());
+    assert(midiData.size() > 3);
+    assert(midiData[0].startTime == 0.0);
+    assert(midiData[1].startTime == 0.0);
 
     Abstractor abs;
     auto notes = abs.convert(midiData);
     assert(notes.size() == midiData.size());
     assert(notes[0].frequency > 0);
+    assert(notes[0].startTime == 0.0);
 
     NoteSynth synth;
+    std::srand(0);
     auto samples = synth.synthesize(notes, 8000);
     assert(!samples.empty());
 
-    int firstCount = static_cast<int>(notes[0].duration * 8000);
-    assert(firstCount >= static_cast<int>(0.8 * 8000));
-    int quarterIdx = static_cast<int>(8000 / (4.0 * notes[0].frequency));
-    if (quarterIdx >= firstCount) {
-        quarterIdx = 0;
+    double totalDuration = 0.0;
+    for (const auto& n : notes) {
+        totalDuration = std::max(totalDuration, n.startTime + n.duration);
     }
-    int endIdx = firstCount - quarterIdx - 1;
-    assert(samples[0] != 0.0);
+    int expectedSamples = static_cast<int>(totalDuration * 8000);
+    assert(samples.size() == static_cast<size_t>(expectedSamples));
+
+    int firstCount = static_cast<int>(notes[0].duration * 8000);
     int sustainIdx = static_cast<int>(firstCount * 0.7);
+    int endIdx = firstCount - 1;
+    assert(samples[0] != 0.0 || samples[1] != 0.0);
     assert(std::abs(samples[endIdx]) < std::abs(samples[sustainIdx]));
 
     OutputHandler out;


### PR DESCRIPTION
## Summary
- allow `MidiMessage` to specify note start times
- add chord in `generateDemo`
- expand `NoteEvent` with start time information
- improve sample generation in `NoteSynth` to mix overlapping notes and reduce hammer noise
- update integration tests for new functionality

## Testing
- `./build_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68568a127a7483339053cfdc19184ad9